### PR TITLE
chore: release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.8] - 2026-02-22
+
+### Bug Fixes
+
+- Use absolute URL for demo GIF so it renders on crates.io
+crates.io doesn't serve repository assets, so relative paths like
+  assets/demo.gif don't work. Use the raw.githubusercontent.com URL.
+
+### Features
+
+- Add social preview image (1280x640)
+Catppuccin Mocha themed preview showing the TUI with pattern input,
+  colored capture group highlights, match results, and explanation panel.
+  Includes the generation script for reproducibility.
+
+
 ## [0.1.7] - 2026-02-22
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,7 +1509,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rgx-cli"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.1.7 -> 0.1.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.8] - 2026-02-22

### Bug Fixes

- Use absolute URL for demo GIF so it renders on crates.io
crates.io doesn't serve repository assets, so relative paths like
  assets/demo.gif don't work. Use the raw.githubusercontent.com URL.

### Features

- Add social preview image (1280x640)
Catppuccin Mocha themed preview showing the TUI with pattern input,
  colored capture group highlights, match results, and explanation panel.
  Includes the generation script for reproducibility.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).