### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-02-22
+
+### Bug Fixes
+
+- Remap help key from ? to F1 so ? can be typed in patterns
+The ? key was intercepted by ShowHelp before reaching InsertChar,
+  making it impossible to type common regex syntax like (?P<name>...),
+  \w+?, (?:...), etc. Remap help to F1 and add UI tests for match
+  display rendering and multi-line test strings.
+- Prevent subtraction overflow in regex input on zero-size terminals
+Use saturating_sub for title truncation width and cursor bounds checks
+  to avoid panicking when the render area has zero width or height.
+
+### Features
+
+- Fix named captures, add scrollable panels and multi-line editor
+- Fix named capture groups in fancy-regex and PCRE2 engines by using
+    capture_names() API instead of hardcoding None
+  - Add scrollable match display and explanation panels with focus cycling
+    across all 4 panels (Tab), scroll via Up/Down on focused panel
+  - Implement multi-line test string editor with Enter for newlines,
+    Up/Down cursor navigation, vertical scroll, and line-aware highlighting
+  - Grow test string area from 3 to 8 rows for multi-line content
+- Add regex pattern syntax highlighting in the input field
+Color parentheses, quantifiers, character classes, escapes, anchors,
+  and alternation operators using the Catppuccin palette. Walks the
+  regex-syntax AST to categorize tokens and builds colored ratatui spans.
+  Falls back to plain text on parse failure.
+- Add live replace/substitution mode with highlighted preview
+Add a replacement input panel between test string and results area,
+  enabling real-time substitution preview. Supports $1, ${name}, $0/$&,
+  and $$ syntax. Engine-agnostic replacement operates on computed match
+  data so it works identically across all three engines.
+
+  - Add ReplaceSegment, ReplaceResult, expand_replacement(), replace_all()
+  - Add replace_editor, replace_result state to App with rereplace() chain
+  - New ReplaceInput widget (single-line, panel index 2)
+  - MatchDisplay renders highlighted preview (green bg for replacements)
+  - Layout updated from 4 to 5 panels, Tab cycles all five
+  - CLI flag -r/--replacement for initial replacement string
+  - 12 new tests (7 unit + 5 integration)
+
+
 ## [0.1.9] - 2026-02-22
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,7 +1509,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rgx-cli"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.1.9"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.1.9 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `rgx-cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ExplanationPanel.scroll in /tmp/.tmpy6UpgT/rgx/src/ui/explanation.rs:15
  field ExplanationPanel.focused in /tmp/.tmpy6UpgT/rgx/src/ui/explanation.rs:16
  field MatchDisplay.replace_result in /tmp/.tmpy6UpgT/rgx/src/ui/match_display.rs:15
  field MatchDisplay.scroll in /tmp/.tmpy6UpgT/rgx/src/ui/match_display.rs:16
  field MatchDisplay.focused in /tmp/.tmpy6UpgT/rgx/src/ui/match_display.rs:17
  field Cli.replacement in /tmp/.tmpy6UpgT/rgx/src/config/cli.rs:41

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Action:InsertNewline in /tmp/.tmpy6UpgT/rgx/src/input/mod.rs:8
  variant Action:ScrollUp in /tmp/.tmpy6UpgT/rgx/src/input/mod.rs:15
  variant Action:ScrollDown in /tmp/.tmpy6UpgT/rgx/src/input/mod.rs:16
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0] - 2026-02-22

### Bug Fixes

- Remap help key from ? to F1 so ? can be typed in patterns
The ? key was intercepted by ShowHelp before reaching InsertChar,
  making it impossible to type common regex syntax like (?P<name>...),
  \w+?, (?:...), etc. Remap help to F1 and add UI tests for match
  display rendering and multi-line test strings.
- Prevent subtraction overflow in regex input on zero-size terminals
Use saturating_sub for title truncation width and cursor bounds checks
  to avoid panicking when the render area has zero width or height.

### Features

- Fix named captures, add scrollable panels and multi-line editor
- Fix named capture groups in fancy-regex and PCRE2 engines by using
    capture_names() API instead of hardcoding None
  - Add scrollable match display and explanation panels with focus cycling
    across all 4 panels (Tab), scroll via Up/Down on focused panel
  - Implement multi-line test string editor with Enter for newlines,
    Up/Down cursor navigation, vertical scroll, and line-aware highlighting
  - Grow test string area from 3 to 8 rows for multi-line content
- Add regex pattern syntax highlighting in the input field
Color parentheses, quantifiers, character classes, escapes, anchors,
  and alternation operators using the Catppuccin palette. Walks the
  regex-syntax AST to categorize tokens and builds colored ratatui spans.
  Falls back to plain text on parse failure.
- Add live replace/substitution mode with highlighted preview
Add a replacement input panel between test string and results area,
  enabling real-time substitution preview. Supports $1, ${name}, $0/$&,
  and $$ syntax. Engine-agnostic replacement operates on computed match
  data so it works identically across all three engines.

  - Add ReplaceSegment, ReplaceResult, expand_replacement(), replace_all()
  - Add replace_editor, replace_result state to App with rereplace() chain
  - New ReplaceInput widget (single-line, panel index 2)
  - MatchDisplay renders highlighted preview (green bg for replacements)
  - Layout updated from 4 to 5 panels, Tab cycles all five
  - CLI flag -r/--replacement for initial replacement string
  - 12 new tests (7 unit + 5 integration)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).