### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1] - 2026-02-22
+
+### Documentation
+
+- Update demo tape for multi-line input and whitespace visualization
+- Add launch post drafts and submission materials
+Show HN, r/rust, r/commandline post drafts, Terminal Trove submission
+  details, and awesome-rust draft entry (deferred until star/download
+  threshold is met). awesome-ratatui PR already submitted ([#248](https://github.com/brevity1swos/rgx/pull/248)).
+- Add launch playbook with step-by-step visibility guide
+
+
 ## [0.4.0] - 2026-02-22
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rgx-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1] - 2026-02-22

### Documentation

- Update demo tape for multi-line input and whitespace visualization
- Add launch post drafts and submission materials
Show HN, r/rust, r/commandline post drafts, Terminal Trove submission
  details, and awesome-rust draft entry (deferred until star/download
  threshold is met). awesome-ratatui PR already submitted ([#248](https://github.com/brevity1swos/rgx/pull/248)).
- Add launch playbook with step-by-step visibility guide
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).