### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - 2026-02-26
+
+### Bug Fixes
+
+- Bounds safety, VecDeque history, config wiring, and code quality
+- Fix scroll_to_selected() bounds check and u16 overflow safety
+  - Change pattern_history from Vec to VecDeque for O(1) front-removal
+  - Add Copy derive to EngineFlags; extract wrap_pattern() to deduplicate
+    flag prefix logic in rust_regex.rs and fancy.rs
+  - Add named panel constants (PANEL_REGEX, PANEL_TEST, etc.) replacing
+    magic numbers; consolidate editor dispatch with closures
+  - Expand Settings with flag fields, parse_engine(); make CLI engine/unicode
+    optional so config defaults apply; wire settings loading in main
+  - Add Unicode edge case tests (emoji, CJK, combining marks), empty
+    state tests, invalid capture ref test, and config deserialization tests
+- Resolve clippy field_reassign_with_default and add launch monitor
+Use struct initialization with ..Default::default() instead of mutable
+  field reassignment in config_tests to satisfy clippy on Rust 1.93.
+
+  Also adds HN/Reddit comment notification monitor script and updates
+  .gitignore for monitor state file.
+
+### Documentation
+
+- Regenerate demo GIF with current features
+- Add syntax highlighting to feature list and bump demo GIF cache
+
+
 ## [0.4.1] - 2026-02-22
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rgx-cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.4.1 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `rgx-cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Settings.case_insensitive in /tmp/.tmpYAxCMm/rgx/src/config/settings.rs:11
  field Settings.multiline in /tmp/.tmpYAxCMm/rgx/src/config/settings.rs:13
  field Settings.dotall in /tmp/.tmpYAxCMm/rgx/src/config/settings.rs:15
  field Settings.unicode in /tmp/.tmpYAxCMm/rgx/src/config/settings.rs:17
  field Settings.extended in /tmp/.tmpYAxCMm/rgx/src/config/settings.rs:19
  field Settings.show_whitespace in /tmp/.tmpYAxCMm/rgx/src/config/settings.rs:21
  field StatusBar.compile_time in /tmp/.tmpYAxCMm/rgx/src/ui/status_bar.rs:28
  field StatusBar.match_time in /tmp/.tmpYAxCMm/rgx/src/ui/status_bar.rs:29

--- failure copy_impl_added: type now implements Copy ---

Description:
A public type now implements Copy, causing non-move closures to capture it by reference instead of moving it.
        ref: https://github.com/rust-lang/rust/issues/100905
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/copy_impl_added.ron

Failed in:
  rgx::engine::EngineFlags in /tmp/.tmpYAxCMm/rgx/src/engine/mod.rs:51

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  Cli::parse_engine, previously in file /tmp/.tmpu832TS/rgx-cli/src/config/cli.rs:45
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0] - 2026-02-26

### Bug Fixes

- Bounds safety, VecDeque history, config wiring, and code quality
- Fix scroll_to_selected() bounds check and u16 overflow safety
  - Change pattern_history from Vec to VecDeque for O(1) front-removal
  - Add Copy derive to EngineFlags; extract wrap_pattern() to deduplicate
    flag prefix logic in rust_regex.rs and fancy.rs
  - Add named panel constants (PANEL_REGEX, PANEL_TEST, etc.) replacing
    magic numbers; consolidate editor dispatch with closures
  - Expand Settings with flag fields, parse_engine(); make CLI engine/unicode
    optional so config defaults apply; wire settings loading in main
  - Add Unicode edge case tests (emoji, CJK, combining marks), empty
    state tests, invalid capture ref test, and config deserialization tests
- Resolve clippy field_reassign_with_default and add launch monitor
Use struct initialization with ..Default::default() instead of mutable
  field reassignment in config_tests to satisfy clippy on Rust 1.93.

  Also adds HN/Reddit comment notification monitor script and updates
  .gitignore for monitor state file.

### Documentation

- Regenerate demo GIF with current features
- Add syntax highlighting to feature list and bump demo GIF cache
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).