### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1] - 2026-02-26
+
+### Documentation
+
+- Revise Show HN post for launch
+Tighten copy for HN audience: shorter title, personal pain point
+  opening, fewer feature bullets, remove self-promotional comparison
+  table, reframe closing CTA around user workflows.
+- Revise r/rust post for launch
+Tighten for r/rust audience: rename technical section to highlight
+  architecture discussion, emphasize trait design and pure Rust build,
+  trim feature list, add concrete details that invite technical feedback.
+
+
 ## [0.5.0] - 2026-02-26
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rgx-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1] - 2026-02-26

### Documentation

- Revise Show HN post for launch
Tighten copy for HN audience: shorter title, personal pain point
  opening, fewer feature bullets, remove self-promotional comparison
  table, reframe closing CTA around user workflows.
- Revise r/rust post for launch
Tighten for r/rust audience: rename technical section to highlight
  architecture discussion, emphasize trait design and pure Rust build,
  trim feature list, add concrete details that invite technical feedback.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).