### PR TITLE
chore: release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.2] - 2026-03-02
+
+### Documentation
+
+- Rewrite positioning with honest audience framing
+Drop "regex101, but in your terminal" tagline in favor of grounded
+  positioning that acknowledges regex101.com as the more capable tool
+  overall. Add "Who is this for?" section to README targeting the actual
+  niche: remote/SSH work, shell pipelines, and engine-specific testing.
+
+  Split comparison table into terminal alternatives (factual) and vs.
+  regex101 (honest prose). Update all launch posts, CLI about string,
+  and Cargo.toml description to match.
+
+
 ## [0.5.1] - 2026-02-26
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.5.1 -> 0.5.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.2] - 2026-03-02

### Documentation

- Rewrite positioning with honest audience framing
Drop "regex101, but in your terminal" tagline in favor of grounded
  positioning that acknowledges regex101.com as the more capable tool
  overall. Add "Who is this for?" section to README targeting the actual
  niche: remote/SSH work, shell pipelines, and engine-specific testing.

  Split comparison table into terminal alternatives (factual) and vs.
  regex101 (honest prose). Update all launch posts, CLI about string,
  and Cargo.toml description to match.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).