### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0] - 2026-03-06
+
+### Features
+
+- Add non-interactive batch mode and pipeline integration
+Add --print/-p flag for non-interactive batch mode that skips the TUI
+  entirely when pattern and input are provided. Add --output-pattern/-P
+  to capture the final pattern after an interactive session.
+
+  Exit codes: 0 = match found, 1 = no match, 2 = error.
+  Input priority: --text > --file > stdin (prevents blocking).
+
+  Update launch posts and playbook with pipeline examples.
+
+
 ## [0.5.2] - 2026-03-02
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.5.2 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `rgx-cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Cli.print in /tmp/.tmpIvAuCd/rgx/src/config/cli.rs:58
  field Cli.output_pattern in /tmp/.tmpIvAuCd/rgx/src/config/cli.rs:63
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0] - 2026-03-06

### Features

- Add non-interactive batch mode and pipeline integration
Add --print/-p flag for non-interactive batch mode that skips the TUI
  entirely when pattern and input are provided. Add --output-pattern/-P
  to capture the final pattern after an interactive session.

  Exit codes: 0 = match found, 1 = no match, 2 = error.
  Input priority: --text > --file > stdin (prevents blocking).

  Update launch posts and playbook with pipeline examples.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).