### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.1] - 2026-03-07
+
+### Refactoring
+
+- Extract print_output method and add CLI flag conflict
+- Extract duplicated output block into App::print_output()
+  - Add conflicts_with = "print" to --output-pattern flag
+  - Remove unnecessary .to_string() clones in batch mode checks
+  - Update terminal_trove.md categories and license
+
+
 ## [0.6.0] - 2026-03-06
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.6.0 -> 0.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.1] - 2026-03-07

### Refactoring

- Extract print_output method and add CLI flag conflict
- Extract duplicated output block into App::print_output()
  - Add conflicts_with = "print" to --output-pattern flag
  - Remove unnecessary .to_string() clones in batch mode checks
  - Update terminal_trove.md categories and license
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).