### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.0] - 2026-03-12
+
+### Bug Fixes
+
+- Move --count into print_output, add conflicts_with, update docs
+- Move count logic into App::print_output() alongside other output modes
+  - Add conflicts_with between --count and --group flags
+  - Update README with --count and --group usage examples
+  - Update launch playbook with current status and r/commandline v2 draft
+
+### Features
+
+- Add Shift+Tab backwards panel cycling and rounded borders option
+- Add Shift+Tab (BackTab) to cycle focus backwards through panels
+  - Add --rounded CLI flag and rounded_borders config option for rounded
+    border characters on all panels and overlays
+  - Pass BorderType through all widget structs and overlay functions
+- *(vim)* Add Action variants for vim motions and mode transitions
+- *(vim)* Add Editor primitives (x, dd, cc, o, O, ^, gg, G, e, paste)
+- *(vim)* Create VimState state machine with pending-key dd/cc/gg support
+- *(vim)* Add --vim CLI flag, config setting, and App integration
+- *(vim)* Wire vim dispatch into event loop with all action handlers
+- *(vim)* Show NORMAL/INSERT mode indicator in status bar and update help
+
+### Refactoring
+
+- *(vim)* Simplify dispatch, fix bugs, improve code quality
+- Move edit_focused/move_focused to App methods with impl FnOnce,
+    eliminating local closures and enabling closure-based dispatch for
+    InsertChar and PasteClipboard (removes ~60 lines of boilerplate)
+  - Fix EnterNormalMode crossing newline boundaries (add move_left_in_line)
+  - Fix o/O reverting to Normal mode when on non-multiline panels
+  - Replace stringly-typed vim mode in StatusBar with Option<VimMode> enum
+  - Switch undo/redo stacks from Vec to VecDeque for O(1) cap eviction
+  - Remove dead MoveToContentEnd and duplicate MoveToLineStart actions
+  - Delegate delete_char_at_cursor to delete_forward (identical logic)
+  - Add VimState::cancel_insert() to encapsulate mode revert
+
+### Testing
+
+- *(vim)* Add integration tests for vim mode
+
+
 ## [0.6.1] - 2026-03-07
 
 ### Refactoring

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.6.1 -> 0.7.0 (⚠ API breaking changes)

### ⚠ `rgx-cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Settings.rounded_borders in /tmp/.tmppFU80O/rgx/src/config/settings.rs:23
  field Settings.vim_mode in /tmp/.tmppFU80O/rgx/src/config/settings.rs:25
  field RegexInput.border_type in /tmp/.tmppFU80O/rgx/src/ui/regex_input.rs:17
  field Cli.rounded in /tmp/.tmppFU80O/rgx/src/config/cli.rs:76
  field Cli.vim in /tmp/.tmppFU80O/rgx/src/config/cli.rs:80
  field TestInput.border_type in /tmp/.tmppFU80O/rgx/src/ui/test_input.rs:18
  field StatusBar.vim_mode in /tmp/.tmppFU80O/rgx/src/ui/status_bar.rs:31
  field ReplaceInput.border_type in /tmp/.tmppFU80O/rgx/src/ui/replace_input.rs:15
  field ExplanationPanel.border_type in /tmp/.tmppFU80O/rgx/src/ui/explanation.rs:17
  field MatchDisplay.border_type in /tmp/.tmppFU80O/rgx/src/ui/match_display.rs:21

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Action:DeleteCharAtCursor in /tmp/.tmppFU80O/rgx/src/input/mod.rs:12
  variant Action:DeleteLine in /tmp/.tmppFU80O/rgx/src/input/mod.rs:13
  variant Action:ChangeLine in /tmp/.tmppFU80O/rgx/src/input/mod.rs:14
  variant Action:OpenLineBelow in /tmp/.tmppFU80O/rgx/src/input/mod.rs:15
  variant Action:OpenLineAbove in /tmp/.tmppFU80O/rgx/src/input/mod.rs:16
  variant Action:MoveToFirstNonBlank in /tmp/.tmppFU80O/rgx/src/input/mod.rs:17
  variant Action:MoveToFirstLine in /tmp/.tmppFU80O/rgx/src/input/mod.rs:18
  variant Action:MoveToLastLine in /tmp/.tmppFU80O/rgx/src/input/mod.rs:19
  variant Action:MoveCursorWordForwardEnd in /tmp/.tmppFU80O/rgx/src/input/mod.rs:26
  variant Action:SwitchPanelBack in /tmp/.tmppFU80O/rgx/src/input/mod.rs:30
  variant Action:PasteClipboard in /tmp/.tmppFU80O/rgx/src/input/mod.rs:43
  variant Action:EnterInsertMode in /tmp/.tmppFU80O/rgx/src/input/mod.rs:49
  variant Action:EnterInsertModeAppend in /tmp/.tmppFU80O/rgx/src/input/mod.rs:50
  variant Action:EnterInsertModeLineStart in /tmp/.tmppFU80O/rgx/src/input/mod.rs:51
  variant Action:EnterInsertModeLineEnd in /tmp/.tmppFU80O/rgx/src/input/mod.rs:52
  variant Action:EnterNormalMode in /tmp/.tmppFU80O/rgx/src/input/mod.rs:53

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  rgx::app::App::print_output now takes 2 parameters instead of 1, in /tmp/.tmppFU80O/rgx/src/app.rs:431
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.0] - 2026-03-12

### Bug Fixes

- Move --count into print_output, add conflicts_with, update docs
- Move count logic into App::print_output() alongside other output modes
  - Add conflicts_with between --count and --group flags
  - Update README with --count and --group usage examples
  - Update launch playbook with current status and r/commandline v2 draft

### Features

- Add Shift+Tab backwards panel cycling and rounded borders option
- Add Shift+Tab (BackTab) to cycle focus backwards through panels
  - Add --rounded CLI flag and rounded_borders config option for rounded
    border characters on all panels and overlays
  - Pass BorderType through all widget structs and overlay functions
- *(vim)* Add Action variants for vim motions and mode transitions
- *(vim)* Add Editor primitives (x, dd, cc, o, O, ^, gg, G, e, paste)
- *(vim)* Create VimState state machine with pending-key dd/cc/gg support
- *(vim)* Add --vim CLI flag, config setting, and App integration
- *(vim)* Wire vim dispatch into event loop with all action handlers
- *(vim)* Show NORMAL/INSERT mode indicator in status bar and update help

### Refactoring

- *(vim)* Simplify dispatch, fix bugs, improve code quality
- Move edit_focused/move_focused to App methods with impl FnOnce,
    eliminating local closures and enabling closure-based dispatch for
    InsertChar and PasteClipboard (removes ~60 lines of boilerplate)
  - Fix EnterNormalMode crossing newline boundaries (add move_left_in_line)
  - Fix o/O reverting to Normal mode when on non-multiline panels
  - Replace stringly-typed vim mode in StatusBar with Option<VimMode> enum
  - Switch undo/redo stacks from Vec to VecDeque for O(1) cap eviction
  - Remove dead MoveToContentEnd and duplicate MoveToLineStart actions
  - Delegate delete_char_at_cursor to delete_forward (identical logic)
  - Add VimState::cancel_insert() to encapsulate mode revert

### Testing

- *(vim)* Add integration tests for vim mode
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).