### PR TITLE
feat: add --workspace flag for project-local workspace files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,6 +1780,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "serde",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ tokio-stream = "0.1"
 
 [dev-dependencies]
 insta = "1"
+tempfile = "3"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -49,8 +49,12 @@ pub struct Cli {
     pub text: Option<String>,
 
     /// Load workspace from file
-    #[arg(short = 'l', long)]
+    #[arg(short = 'l', long, conflicts_with = "workspace")]
     pub load: Option<String>,
+
+    /// Use a workspace file for save/load (creates if missing)
+    #[arg(short = 'w', long, conflicts_with = "load")]
+    pub workspace: Option<String>,
 
     /// Print matches to stdout and exit (non-interactive batch mode).
     /// Requires a pattern and input (stdin, --file, or --text).

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,12 +65,20 @@ async fn run() -> anyhow::Result<ExitCode> {
         app.vim_mode = true;
     }
 
-    // Load workspace if --load is set
+    // Load workspace if --load or --workspace is set
     if let Some(ref load_path) = cli.load {
         use rgx::config::workspace::Workspace;
         let ws = Workspace::load(std::path::Path::new(load_path))?;
         ws.apply(&mut app);
         app.workspace_path = Some(load_path.clone());
+    } else if let Some(ref ws_path) = cli.workspace {
+        use rgx::config::workspace::Workspace;
+        let path = std::path::Path::new(ws_path);
+        if path.exists() {
+            let ws = Workspace::load(path)?;
+            ws.apply(&mut app);
+        }
+        app.workspace_path = Some(ws_path.clone());
     }
 
     // Load test string: --text and --file take priority over stdin

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,5 +1,6 @@
 use rgx::config::settings::Settings;
-use rgx::engine::EngineKind;
+use rgx::config::workspace::Workspace;
+use rgx::engine::{EngineFlags, EngineKind};
 
 #[test]
 fn test_settings_defaults() {
@@ -80,4 +81,62 @@ fn test_settings_empty_toml() {
     let settings: Settings = toml::from_str("").unwrap();
     assert_eq!(settings.default_engine, "rust");
     assert!(settings.unicode);
+}
+
+#[test]
+fn test_workspace_round_trip() {
+    let flags = EngineFlags {
+        case_insensitive: true,
+        multi_line: false,
+        dot_matches_newline: true,
+        unicode: true,
+        extended: false,
+    };
+    let mut app = rgx::app::App::new(EngineKind::FancyRegex, flags);
+    app.set_pattern(r"\d{3}-\d{4}");
+    app.set_test_string("Call 555-1234 today");
+    app.set_replacement("XXX-XXXX");
+
+    let ws = Workspace::from_app(&app);
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.toml");
+    ws.save(&path).unwrap();
+
+    let loaded = Workspace::load(&path).unwrap();
+    assert_eq!(loaded.pattern, r"\d{3}-\d{4}");
+    assert_eq!(loaded.test_string, "Call 555-1234 today");
+    assert_eq!(loaded.replacement, "XXX-XXXX");
+    assert_eq!(loaded.engine, "fancy");
+    assert!(loaded.case_insensitive);
+    assert!(!loaded.multiline);
+    assert!(loaded.dotall);
+    assert!(loaded.unicode);
+    assert!(!loaded.extended);
+}
+
+#[test]
+fn test_workspace_apply_restores_state() {
+    let flags = EngineFlags::default();
+    let mut app = rgx::app::App::new(EngineKind::RustRegex, flags);
+
+    let toml_str = r#"
+pattern = "hello+"
+test_string = "hellooo world"
+replacement = ""
+engine = "fancy"
+case_insensitive = true
+multiline = false
+dotall = false
+unicode = true
+extended = false
+show_whitespace = true
+"#;
+    let ws: Workspace = toml::from_str(toml_str).unwrap();
+    ws.apply(&mut app);
+
+    assert_eq!(app.regex_editor.content(), "hello+");
+    assert_eq!(app.test_editor.content(), "hellooo world");
+    assert_eq!(app.engine_kind, EngineKind::FancyRegex);
+    assert!(app.flags.case_insensitive);
+    assert!(app.show_whitespace);
 }


### PR DESCRIPTION
I have added `-w/--workspace` to make rgx load from and save to a specified file path (and create one if it does not exist), rather than the default one.

The idea is to make it easy to use rgx to develop multiple regular expressions as part of a project, and track each regex pattern with all its settings and test strings in a separate workspace file, and, **most importantly, add those files to git**.

So for example a developer would run:

`rgx -w ~/myProject/regex/parse_command_from_url.toml`

Here, `regex` is a folder that developers setup in their codebase for regex development and testing.

`parse_command_from_url.toml` is a single such regex development project (in fact, just an rgx workspace).

At the end of the day, the developer workflow is:
- load an existing or specify a new workspace file: `rgx -w <path>`
- play with it, then `Ctrl+S` _(save)_
- git commit the workspace file

====

NOTE: I'm not a Rust developer. I used Claude in the maximum thinking mode and with the best model available, then reviewed the code manually, and tested it manually as well. Everything works as expected and as intended, and the code changes look reasonable to me. If something is wrong, please do let me know and I'll address it. Also, it was a nice first experience and intro into Rust for me.