### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.0] - 2026-03-24
+
+### Bug Fixes
+
+- Filter key events to Press-only to prevent WSL double input
+On Windows/WSL, crossterm emits Press, Release, and Repeat key events.
+  Without filtering, each keystroke produced duplicate characters.
+- Remove pcre2-engine from default features
+Pre-built binaries dynamically linked to libpcre2, requiring Homebrew on
+  macOS. PCRE2 is now opt-in via --all-features or --features pcre2-engine.
+  Also adds clap_complete and serde_json dependencies for new features.
+
+### Features
+
+- Add --workspace flag for project-local workspace files
+- Add --completions, --json, and --color flags
+- --completions <SHELL>: generate shell completions for bash/zsh/fish
+    using clap_complete (closes #36)
+  - --json: output matches as structured JSON in batch mode (closes #37)
+  - --color auto|always|never: ANSI-highlighted match output in batch
+    mode, similar to grep --color (closes #38)
+- Add regex101 URL export (Ctrl+U) and colored/JSON output support
+- Ctrl+U generates a regex101.com URL from current state and copies to
+    clipboard, with engine-appropriate flavor mapping (closes #40)
+  - print_output() gains color support for highlighted match context
+  - print_json_output() produces structured JSON with match positions
+    and capture groups
+
+
 ## [0.7.0] - 2026-03-12
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,7 +1774,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)

### ⚠ `rgx-cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Cli.workspace in /tmp/.tmpWCK50B/rgx/src/config/cli.rs:58
  field Cli.json in /tmp/.tmpWCK50B/rgx/src/config/cli.rs:81
  field Cli.color in /tmp/.tmpWCK50B/rgx/src/config/cli.rs:85
  field Cli.completions in /tmp/.tmpWCK50B/rgx/src/config/cli.rs:97

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Action:ExportRegex101 in /tmp/.tmpWCK50B/rgx/src/input/mod.rs:49

--- failure feature_not_enabled_by_default: package feature is not enabled by default ---

Description:
A feature is no longer enabled by default for this package. This will break downstream crates which rely on the package's default features and require the functionality of this feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove-another
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/feature_not_enabled_by_default.ron

Failed in:
  feature pcre2-engine in the package's Cargo.toml

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  rgx::app::App::print_output now takes 3 parameters instead of 2, in /tmp/.tmpWCK50B/rgx/src/app.rs:431
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0] - 2026-03-24

### Bug Fixes

- Filter key events to Press-only to prevent WSL double input
On Windows/WSL, crossterm emits Press, Release, and Repeat key events.
  Without filtering, each keystroke produced duplicate characters.
- Remove pcre2-engine from default features
Pre-built binaries dynamically linked to libpcre2, requiring Homebrew on
  macOS. PCRE2 is now opt-in via --all-features or --features pcre2-engine.
  Also adds clap_complete and serde_json dependencies for new features.

### Features

- Add --workspace flag for project-local workspace files
- Add --completions, --json, and --color flags
- --completions <SHELL>: generate shell completions for bash/zsh/fish
    using clap_complete (closes #36)
  - --json: output matches as structured JSON in batch mode (closes #37)
  - --color auto|always|never: ANSI-highlighted match output in batch
    mode, similar to grep --color (closes #38)
- Add regex101 URL export (Ctrl+U) and colored/JSON output support
- Ctrl+U generates a regex101.com URL from current state and copies to
    clipboard, with engine-appropriate flavor mapping (closes #40)
  - print_output() gains color support for highlighted match context
  - print_json_output() produces structured JSON with match positions
    and capture groups
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).