### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.1] - 2026-03-25
+
+### Documentation
+
+- Update README, demo, and r/commandline post for v0.8.0
+- README: add --json, --color, --completions, Ctrl+U, -w workspace,
+    Ctrl+B benchmark to features, usage, shortcuts, and comparison table.
+    Update PCRE2 install instructions (now opt-in).
+  - demo.tape: add batch mode section (--json, --color) and Ctrl+U
+    regex101 export to interactive section.
+  - r_commandline.md: v3 draft with v0.8.0 features for repost.
+- Regenerate demo GIF with v0.8.0 features
+Includes --json output, --color always, and Ctrl+U regex101 export.
+- Bust GIF cache (v=4)
+- Update Show HN draft for v0.8.0
+- Add editor plugins design spec
+- Add editor plugins implementation plan
+- Add Editor & Terminal Integration section to README
+VS Code, Neovim, Zed, and tmux integration instructions.
+
+### Features
+
+- *(zed)* Add task definitions for rgx integration
+- *(vscode)* Add VS Code extension with 3 terminal commands
+- rgx: Open — launch rgx in integrated terminal
+  - rgx: Open with Selection — pass selected text as --text
+  - rgx: Open with Pattern — pass selected text as pattern arg
+  - Configurable binary path and default engine
+
+### Miscellaneous
+
+- *(vscode)* Add .gitignore, untrack node_modules/out/.vsix
+- Add .env.local to .gitignore
+
+### Refactoring
+
+- Extract clipboard helper, derive Serialize, ANSI constants
+- Extract copy_to_clipboard() helper to deduplicate clipboard error
+    handling between copy_selected_match() and copy_regex101_url()
+  - Derive Serialize on Match/CaptureGroup with serde rename attrs,
+    replacing 30 lines of manual JSON construction in print_json_output()
+  - Extract ANSI escape codes into named constants (ANSI_RED_BOLD,
+    ANSI_GREEN_BOLD, ANSI_RESET)
+
+### Ci
+
+- Add VS Code extension publish workflow
+- Restrict dist.yml to v-prefixed semver tags only
+
+
 ## [0.8.0] - 2026-03-24
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,7 +1774,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.8.0 -> 0.8.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.1] - 2026-03-25

### Documentation

- Update README, demo, and r/commandline post for v0.8.0
- README: add --json, --color, --completions, Ctrl+U, -w workspace,
    Ctrl+B benchmark to features, usage, shortcuts, and comparison table.
    Update PCRE2 install instructions (now opt-in).
  - demo.tape: add batch mode section (--json, --color) and Ctrl+U
    regex101 export to interactive section.
  - r_commandline.md: v3 draft with v0.8.0 features for repost.
- Regenerate demo GIF with v0.8.0 features
Includes --json output, --color always, and Ctrl+U regex101 export.
- Bust GIF cache (v=4)
- Update Show HN draft for v0.8.0
- Add editor plugins design spec
- Add editor plugins implementation plan
- Add Editor & Terminal Integration section to README
VS Code, Neovim, Zed, and tmux integration instructions.

### Features

- *(zed)* Add task definitions for rgx integration
- *(vscode)* Add VS Code extension with 3 terminal commands
- rgx: Open — launch rgx in integrated terminal
  - rgx: Open with Selection — pass selected text as --text
  - rgx: Open with Pattern — pass selected text as pattern arg
  - Configurable binary path and default engine

### Miscellaneous

- *(vscode)* Add .gitignore, untrack node_modules/out/.vsix
- Add .env.local to .gitignore

### Refactoring

- Extract clipboard helper, derive Serialize, ANSI constants
- Extract copy_to_clipboard() helper to deduplicate clipboard error
    handling between copy_selected_match() and copy_regex101_url()
  - Derive Serialize on Match/CaptureGroup with serde rename attrs,
    replacing 30 lines of manual JSON construction in print_json_output()
  - Extract ANSI escape codes into named constants (ANSI_RED_BOLD,
    ANSI_GREEN_BOLD, ANSI_RESET)

### Ci

- Add VS Code extension publish workflow
- Restrict dist.yml to v-prefixed semver tags only
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).