### PR TITLE
chore: release v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.2] - 2026-04-09
+
+### Bug Fixes
+
+- Pcre2 zero-length match offset bug, replace bare unwrap with expect
+- Fix `offset += abs_end + 1` → `offset = abs_end + 1` in PCRE2
+    find_matches() — the += caused skipped matches when a zero-length
+    match occurred at a non-zero position after the first iteration
+  - Replace bare .unwrap() with .expect() on capture group 0 across all
+    three engine implementations (rust_regex, fancy, pcre2) and in
+    expand_replacement() for peeked iterator values
+  - Deduplicate whitespace visualization flush pattern in test_input.rs
+
+### Documentation
+
+- Update CONTRIBUTING.md architecture section
+Add codegen, recipe, ansi, workspace, debugger, syntax highlighting,
+  and vim mode to the architecture overview. Reflects current v0.10.1
+  source tree.
+
+
 ## [0.10.1] - 2026-04-08
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,7 +1774,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.10.1 -> 0.10.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.2] - 2026-04-09

### Bug Fixes

- Pcre2 zero-length match offset bug, replace bare unwrap with expect
- Fix `offset += abs_end + 1` → `offset = abs_end + 1` in PCRE2
    find_matches() — the += caused skipped matches when a zero-length
    match occurred at a non-zero position after the first iteration
  - Replace bare .unwrap() with .expect() on capture group 0 across all
    three engine implementations (rust_regex, fancy, pcre2) and in
    expand_replacement() for peeked iterator values
  - Deduplicate whitespace visualization flush pattern in test_input.rs

### Documentation

- Update CONTRIBUTING.md architecture section
Add codegen, recipe, ansi, workspace, debugger, syntax highlighting,
  and vim mode to the architecture overview. Reflects current v0.10.1
  source tree.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).