### PR TITLE
chore: release v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.2] - 2026-04-19
+
+### Documentation
+
+- Restore rgx to independent-project presentation
+Reverts the stepwise-umbrella positioning that briefly appeared in the
+  README and the ROADMAP earlier today. rgx stays presented as a
+  standalone project; sibling-tool synergy lives on the separate
+  stepwise landing page (out of this repo). Users who arrived at rgx
+  through Terminal Trove, awesome-ratatui, or AUR didn't sign up for a
+  three-tool stack pitch on their regex debugger's README — putting
+  one there muddles the value proposition.
+
+
 ## [0.12.1] - 2026-04-19
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.12.1 -> 0.12.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.2] - 2026-04-19

### Documentation

- Restore rgx to independent-project presentation
Reverts the stepwise-umbrella positioning that briefly appeared in the
  README and the ROADMAP earlier today. rgx stays presented as a
  standalone project; sibling-tool synergy lives on the separate
  stepwise landing page (out of this repo). Users who arrived at rgx
  through Terminal Trove, awesome-ratatui, or AUR didn't sign up for a
  three-tool stack pitch on their regex debugger's README — putting
  one there muddles the value proposition.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).