### PR TITLE
chore: release v0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.3] - 2026-05-11
+
+### Documentation
+
+- *(changelog)* Scrub private project references from history entries
+Remove mentions of sibling tools and the landing-site project from
+  changelog entries across v0.12.0–v0.12.2. Inline descriptions now
+  reference only rgx-visible concepts (piping, filter mode, standalone
+  presentation) so the public changelog is self-contained.
+
+
 ## [0.12.2] - 2026-04-19
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.12.2 -> 0.12.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.3] - 2026-05-11

### Documentation

- *(changelog)* Scrub private project references from history entries
Remove mentions of sibling tools and the landing-site project from
  changelog entries across v0.12.0–v0.12.2. Inline descriptions now
  reference only rgx-visible concepts (piping, filter mode, standalone
  presentation) so the public changelog is self-contained.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).