### PR TITLE
chore: release v0.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.5] - 2026-05-31
+
+### Refactoring
+
+- *(tests)* Clear pedantic clippy warnings in test code
+Five test-only clippy warnings that were left from the v0.12.4
+  maintenance sweep. None affect runtime; all were CI-silent (the project
+  enforces -D warnings without pedantic). Cleaned up so a future pedantic
+  audit starts from zero:
+
+  - tests/filter_tests.rs: replace `(0..N).map(format!).collect()` with
+    a loop using writeln! (format_collect × 2)
+  - src/ui/syntax_highlight.rs::test_dot: collapse `Vec collect + contains`
+    to `.any()` (needless_collect)
+  - src/ui/syntax_highlight.rs::test_named_group: collapse `Vec collect +
+    .len()` to `.count()` (needless_collect)
+  - tests/engine_tests.rs::run_print: switch Path Debug formatting to
+    Display via `bin.display()` (unnecessary_debug_formatting)
+
+
 ## [0.12.4] - 2026-05-31
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.12.4 -> 0.12.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.5] - 2026-05-31

### Refactoring

- *(tests)* Clear pedantic clippy warnings in test code
Five test-only clippy warnings that were left from the v0.12.4
  maintenance sweep. None affect runtime; all were CI-silent (the project
  enforces -D warnings without pedantic). Cleaned up so a future pedantic
  audit starts from zero:

  - tests/filter_tests.rs: replace `(0..N).map(format!).collect()` with
    a loop using writeln! (format_collect × 2)
  - src/ui/syntax_highlight.rs::test_dot: collapse `Vec collect + contains`
    to `.any()` (needless_collect)
  - src/ui/syntax_highlight.rs::test_named_group: collapse `Vec collect +
    .len()` to `.count()` (needless_collect)
  - tests/engine_tests.rs::run_print: switch Path Debug formatting to
    Display via `bin.display()` (unnecessary_debug_formatting)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).