### PR TITLE
chore: release v0.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.6] - 2026-06-02
+
+### Features
+
+- *(ui)* Add scrollability and hjkl navigation to help overlay ([#73](https://github.com/brevity1swos/rgx/pull/73))
+
+
 ## [0.12.5] - 2026-05-31
 
 ### Refactoring

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.12.5"
+version = "0.12.6"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.12.5"
+version = "0.12.6"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.12.5 -> 0.12.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.6] - 2026-06-02

### Features

- *(ui)* Add scrollability and hjkl navigation to help overlay ([#73](https://github.com/brevity1swos/rgx/pull/73))
feat(ui): add scrollability and hjkl navigation to help pages

  remove if/else in place of div_ceil

  docs(readme): document Ctrl+B, Ctrl+U, and -P in features list
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).