### PR TITLE
chore: release v0.12.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.7] - 2026-06-06
+
+### Bug Fixes
+
+- *(clipboard)* Fix empty clipboard on Linux after Ctrl+Y (#78)
+arboard's `Clipboard` releases the X11 selection as soon as it's
+  dropped, which the old code did immediately after `set_text`. Now we
+  use `SetExtLinux::wait()` spawned in a detached background thread to
+  hold the selection alive while keeping the TUI responsive. The thread
+  releases when the user copies something else; persistence across rgx
+  exit still requires a clipboard manager on the user's side.
+
+
 ## [0.12.6] - 2026-06-02
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.12.6"
+version = "0.12.7"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.12.6"
+version = "0.12.7"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.12.6 -> 0.12.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.7] - 2026-06-06

### Bug Fixes

- *(clipboard)* Persist Linux clipboard via SetExtLinux::wait()
Reported in #78: on Linux, pressing Ctrl+Y to copy a pattern or match
  left the system clipboard empty when checked from another app.

  Root cause: arboard's docs state explicitly — "Using either Wayland and
  X11, the clipboard and its content is 'hosted' inside of the application
  that last put data onto it. This means that when the last `Clipboard`
  instance is dropped, the contents may become unavailable to other apps."
  `copy_to_clipboard` created a fresh `arboard::Clipboard` per call, wrote
  the text, and dropped the instance immediately — so the X11 selection
  ownership reverted as soon as the function returned, leaving the
  clipboard empty by the time the user could check it elsewhere.
- *(clipboard)* Run SetExtLinux::wait() in detached thread
Follow-up to ba816f1. On minimal X11 setups with no clipboard manager
  daemon (reported by clearins1ght on Artix + OpenRC + DWM via .xinitrc,
  issue #78), `arboard::SetExtLinux::wait()` never returns on its own —
  it blocks until another app reads the clipboard, and nothing
  automatically does so. Calling it from the TUI event loop froze rgx
  after every Ctrl+Y.

  Spawn the wait() into a detached background thread instead. The thread
  holds the X11 selection until either (a) the user copies something
  else (wait() returns cleanly, thread exits) or (b) rgx itself exits
  (thread is killed). Trade-off: persistence after rgx exit still
  requires a clipboard manager on the user's side — we'd need to fork
  into a separate process to survive rgx's death, which is more invasive
  than warranted for the maintenance-mode scope.

  Cross-checked compile on `x86_64-unknown-linux-gnu --no-default-features`
  and on macOS native. Linux behavior awaits real-environment confirmation
  from clearins1ght.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).