### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.0] - 2026-06-06
+
+### Bug Fixes
+
+- *(ui)* Show transient status messages in the bottom status bar ([#78](https://github.com/brevity1swos/rgx/pull/78))
+
+
 ## [0.12.7] - 2026-06-06
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.12.7"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.12.7"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.12.7 -> 0.13.0 (⚠ API breaking changes)

### ⚠ `rgx-cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field StatusBar.clipboard_status in /tmp/.tmpjFWvmA/rgx/src/ui/status_bar.rs:37

--- failure type_mismatched_generic_lifetimes: type now takes a different number of generic lifetimes ---

Description:
A type now takes a different number of generic lifetime parameters. Uses of this type that name the previous number of parameters will be broken.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/type_mismatched_generic_lifetimes.ron
Failed in:
  Struct StatusBar (0 -> 1 lifetime params) in /tmp/.tmpjFWvmA/rgx/src/ui/status_bar.rs:24
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.0] - 2026-06-06

### Bug Fixes

- *(ui)* Show transient status messages in the bottom status bar ([#78](https://github.com/brevity1swos/rgx/pull/78))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).