### PR TITLE
chore: release v0.12.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.8] - 2026-06-06
+
+### Bug Fixes
+
+- *(ui)* Show "Copied …" status message in the bottom status bar after Ctrl+Y ([#78](https://github.com/brevity1swos/rgx/pull/78))
+The clipboard success message was being set on `app.status` but only
+  rendered inside the matches panel. Now drawn as an overlay over the
+  status bar's right edge for ~2 seconds, visible from any focused
+  panel.
+
+
 ## [0.12.7] - 2026-06-06
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.12.7"
+version = "0.12.8"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.12.7 -> 0.12.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.8] - 2026-06-06

### Bug Fixes

- *(ui)* Show transient status messages in the bottom status bar ([#78](https://github.com/brevity1swos/rgx/pull/78))
- *(ui)* Render status message as overlay instead of StatusBar field ([#78](https://github.com/brevity1swos/rgx/pull/78))
Follow-up to 82acfbe. The prior commit added a `clipboard_status`
  field to the public `StatusBar` struct + a lifetime parameter, which
  release-plz's cargo-semver-checks correctly classified as a breaking
  change and proposed v0.13.0. rgx is in patch-level maintenance mode;
  a minor bump for a UX bug fix is out of proportion.

  Walk back the StatusBar changes (struct returns to its v0.12.7 shape).
  Implement the same fix as a transient overlay drawn on top of the
  status bar's right edge in `ui/mod.rs::render`, gated on
  `app.status.text.is_some()`. The visual outcome is identical for end
  users — message appears in the status bar area for ~2 seconds after
  Ctrl+Y — but the public API surface is unchanged versus v0.12.7, so
  the next release reverts to a patch bump.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).