### PR TITLE
chore: release v0.12.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.9] - 2026-06-06
+
+### Refactoring
+
+- Clippy sweep across 3 files — no behavior change
+
+
 ## [0.12.8] - 2026-06-06
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.12.8"
+version = "0.12.9"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.12.8 -> 0.12.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.9] - 2026-06-06

### Refactoring

- Post-v0.12.8 clippy sweep
Mechanical clippy autofixes + one manual fix surfaced after the v0.12.8
  ship:

  - src/ui/mod.rs: inline named-width format arg
    (`{key:<width$}, width = HELP_PAGE_COL_0_WIDTH` -> `{key:<HELP_PAGE_COL_0_WIDTH$}`).
  - src/filter/ui.rs: `map(Vec::as_slice).unwrap_or(&[])` -> `map_or(&[], Vec::as_slice)`.
  - tests/ui_tests.rs: promote `press_key` helper to `const fn` and inline
    format args in assert / panic messages.

  No behavior change. All tests + lint clean.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).