### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.0] - 2026-06-07
+
+### Features
+
+- *(ui)* Add F3-toggled Quick Reference side panel ([#83](https://github.com/brevity1swos/rgx/pull/83))
+Adds an opt-in Quick Reference panel that the user can toggle on the
+  right side of the screen with F3. Reuses the existing F1 help-page-1
+  content (sequences / classes & groups / quantifiers / replacement)
+  so the side panel and the help overlay never drift out of sync.
+
+  UX choices:
+  - Off by default — respects screen estate (per #83's "alternative
+    considered"); user toggles in when they want quick lookup without
+    losing the editor view.
+  - 38 cols wide; panel is suppressed when the terminal is too narrow
+    to keep the main results area (Matches + Explanation) usable
+    (< 60 cols left). Toggle still flips the App state; panel rendering
+    is gated on width so the user can widen the terminal and see it
+    appear without re-toggling.
+  - F-key family (F1 = help overlay, F2 = recipes, F3 = quickref) keeps
+    the discoverability story consistent. ? was deliberately avoided
+    per the lesson from #78 — it collides with regex syntax in the
+    editor.
+
+
 ## [0.12.9] - 2026-06-06
 
 ### Refactoring

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.12.9"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.12.9"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.12.9 -> 0.13.0 (⚠ API breaking changes)

### ⚠ `rgx-cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PanelLayout.quickref in /tmp/.tmpega0Cb/rgx/src/ui/mod.rs:55

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant Action:ToggleQuickref in /tmp/.tmpega0Cb/rgx/src/input/mod.rs:46

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rgx::ui::compute_layout now takes 2 parameters instead of 1, in /tmp/.tmpega0Cb/rgx/src/ui/mod.rs:65
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.0] - 2026-06-07

### Features

- *(ui)* Add F3-toggled Quick Reference side panel ([#83](https://github.com/brevity1swos/rgx/pull/83))
Adds an opt-in Quick Reference panel that the user can toggle on the
  right side of the screen with F3. Reuses the existing F1 help-page-1
  content (sequences / classes & groups / quantifiers / replacement)
  so the side panel and the help overlay never drift out of sync.

  UX choices:
  - Off by default — respects screen estate (per #83's "alternative
    considered"); user toggles in when they want quick lookup without
    losing the editor view.
  - 38 cols wide; panel is suppressed when the terminal is too narrow
    to keep the main results area (Matches + Explanation) usable
    (< 60 cols left). Toggle still flips the App state; panel rendering
    is gated on width so the user can widen the terminal and see it
    appear without re-toggling.
  - F-key family (F1 = help overlay, F2 = recipes, F3 = quickref) keeps
    the discoverability story consistent. ? was deliberately avoided
    per the lesson from #78 — it collides with regex syntax in the
    editor.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).