### PR TITLE
chore: release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.1] - 2026-06-08
+
+### Bug Fixes
+
+- *(ui)* Remove broken Quick Reference scroll clamp ([#83](https://github.com/brevity1swos/rgx/pull/83))
+clearins1ght reported scroll being inert across Alacritty, Kitty, and
+  st at every zoom level — including the ones where the bottom of the
+  Quick Reference content was visibly clipped. The clamp at
+  `src/ui/mod.rs::render` capped `scroll` at
+  `lines.len() - (panel_height - 2)`, intended to keep the user from
+  scrolling into blank space. But `lines.len()` is the **source** line
+  count (~25); `Paragraph::wrap(Wrap { trim: false })` then renders
+  long headers and shortcut lines as 2 rendered rows each, so the real
+  content occupies ~35 rendered rows on a 36-column text area. The
+  clamp underestimates this and pinned `scroll` to 0 on the very
+  viewports where scrolling was meant to help.
+
+  Pass `app.quickref_scroll` directly into `Paragraph::scroll`. The
+  ratatui paragraph happily renders blank rows past the end of content
+  when over-scrolled, so the worst case on a too-tall terminal is the
+  user pressing PgDn into emptiness — PgUp brings them back. Strictly
+  better than the previous "always pinned to 0" behavior.
+
+  Diagnosis path is documented in #83's comment thread.
+
+
 ## [0.14.0] - 2026-06-07
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgx-cli"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgx-cli"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 rust-version = "1.74"
 authors = ["rgx contributors"]


### PR DESCRIPTION



## 🤖 New release

* `rgx-cli`: 0.14.0 -> 0.14.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.1] - 2026-06-08

### Bug Fixes

- *(ui)* Remove broken Quick Reference scroll clamp ([#83](https://github.com/brevity1swos/rgx/pull/83))
clearins1ght reported scroll being inert across Alacritty, Kitty, and
  st at every zoom level — including the ones where the bottom of the
  Quick Reference content was visibly clipped. The clamp at
  `src/ui/mod.rs::render` capped `scroll` at
  `lines.len() - (panel_height - 2)`, intended to keep the user from
  scrolling into blank space. But `lines.len()` is the **source** line
  count (~25); `Paragraph::wrap(Wrap { trim: false })` then renders
  long headers and shortcut lines as 2 rendered rows each, so the real
  content occupies ~35 rendered rows on a 36-column text area. The
  clamp underestimates this and pinned `scroll` to 0 on the very
  viewports where scrolling was meant to help.

  Pass `app.quickref_scroll` directly into `Paragraph::scroll`. The
  ratatui paragraph happily renders blank rows past the end of content
  when over-scrolled, so the worst case on a too-tall terminal is the
  user pressing PgDn into emptiness — PgUp brings them back. Strictly
  better than the previous "always pinned to 0" behavior.

  Diagnosis path is documented in #83's comment thread.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).